### PR TITLE
feat: Claude Code Review Actionでsticky commentを有効化

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -52,7 +52,7 @@ jobs:
             Be constructive and helpful in your feedback.
 
           # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
-          # use_sticky_comment: true
+          use_sticky_comment: true
           
           # Optional: Customize review based on file types
           # direct_prompt: |

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -51,7 +51,6 @@ jobs:
             
             Be constructive and helpful in your feedback.
 
-          # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
           use_sticky_comment: true
           
           # Optional: Customize review based on file types


### PR DESCRIPTION
## Summary
- Issue #5 の要望に従い、`.github/workflows/claude-code-review.yml` で `use_sticky_comment: true` を有効化しました

## 変更内容
- `use_sticky_comment` オプションのコメントアウトを解除
- これにより、同じPRへの後続のプッシュ時にClaudeが既存のコメントを再利用するようになります
- PR内の会話がよりクリーンに保たれ、レビューコメントの管理が改善されます

## Test plan
- [x] GitHub ActionsでClaude Code Reviewが正常に動作することを確認
- [ ] 後続のコミットで既存のコメントが更新されることを確認

Closes #5

🤖 Generated with [Claude Code](https://claude.ai/code)