### PR TITLE
fix: コンテンツスライドを左揃えに変更

### DIFF
--- a/src/components/Slide.tsx
+++ b/src/components/Slide.tsx
@@ -11,13 +11,7 @@ export const Slide: React.FC<SlideProps> = ({ title, content }) => {
   const processedLines = processContent(content)
 
   return (
-    <Box
-      flexDirection="column"
-      padding={2}
-      alignItems="center"
-      justifyContent="center"
-      width="100%"
-    >
+    <Box flexDirection="column" padding={2} width="100%">
       {title && (
         <Box marginBottom={1}>
           <Text bold color="yellow" underline>
@@ -25,9 +19,7 @@ export const Slide: React.FC<SlideProps> = ({ title, content }) => {
           </Text>
         </Box>
       )}
-      <Box flexDirection="column" alignItems="center">
-        {processedLines}
-      </Box>
+      <Box flexDirection="column">{processedLines}</Box>
     </Box>
   )
 }


### PR DESCRIPTION
## Summary
- コンテンツスライドの中央揃えを左揃えに変更し、読みやすさを改善
- タイトルスライドは中央揃えのまま維持

## 変更理由
現在、タイトル・コンテンツともに中央揃えになっていましたが、コンテンツページの箇条書きなどが中央揃えだと非常に読みづらかったため、左揃えに変更しました。

## 変更内容
- `Slide.tsx`から`alignItems="center"`と`justifyContent="center"`を削除
- コンテンツが左揃えで表示されるように修正
- `TitleSlide.tsx`は変更なし（中央揃えのまま）

## Test plan
- [x] `npm run dev`でスライドショーを実行し、コンテンツが左揃えになることを確認
- [x] タイトルスライドが中央揃えのままであることを確認
- [x] すべてのスライドが正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)