### PR TITLE
feat: PR#11レビュー指摘事項への対応

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "ink": "^6.0.1",
     "ink-big-text": "^2.0.0",
     "ink-gradient": "^3.0.0",
-    "js-yaml": "^4.1.0",
     "react": "^19.1.0",
     "tsx": "^4.20.3",
     "typescript": "^5.8.3"
@@ -50,7 +49,6 @@
   "devDependencies": {
     "@biomejs/biome": "^2.1.2",
     "@testing-library/react": "^16.3.0",
-    "@types/js-yaml": "^4.0.9",
     "@vitest/ui": "^3.2.4",
     "ink-testing-library": "^4.0.0",
     "vitest": "^3.2.4"

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -3,12 +3,12 @@ import { existsSync, readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { Box, render } from 'ink'
-import yaml from 'js-yaml'
 import { SlideShow } from './index.js'
 import type { SlideData } from './types/slide.js'
+import { validateSlideData } from './utils/slideValidator.js'
+import { parseYaml } from './utils/yamlParser.js'
 
 // YAMLファイル読み込み
-// Note: js-yaml v4.x では load() がデフォルトで安全になったため、safeLoad() は削除されました
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
 
@@ -23,18 +23,12 @@ try {
   }
 
   const yamlContent = readFileSync(yamlPath, 'utf-8')
-  slidesData = yaml.load(yamlContent) as SlideData[]
-
-  // 基本的なバリデーション
-  if (!Array.isArray(slidesData)) {
-    console.error('Error: slides.yaml must contain an array of slides')
-    process.exit(1)
-  }
-
-  if (slidesData.length === 0) {
-    console.error('Error: slides.yaml must contain at least one slide')
-    process.exit(1)
-  }
+  
+  // カスタムYAMLパーサーでパース
+  const parsedData = parseYaml(yamlContent)
+  
+  // 型ガードと詳細なバリデーション
+  slidesData = validateSlideData(parsedData)
 } catch (error) {
   if (error instanceof Error) {
     console.error('Failed to load slides.yaml:', error.message)

--- a/src/utils/slideValidator.ts
+++ b/src/utils/slideValidator.ts
@@ -1,0 +1,99 @@
+import type { ContentSlideData, SlideData, TitleSlideData } from '../types/slide.js'
+
+export function isTitleSlide(slide: unknown): slide is TitleSlideData {
+  if (typeof slide !== 'object' || slide === null) {
+    return false
+  }
+
+  const obj = slide as Record<string, unknown>
+  
+  return (
+    obj.type === 'title' &&
+    typeof obj.title === 'string' &&
+    (obj.subtitle === undefined || typeof obj.subtitle === 'string') &&
+    (obj.author === undefined || typeof obj.author === 'string')
+  )
+}
+
+export function isContentSlide(slide: unknown): slide is ContentSlideData {
+  if (typeof slide !== 'object' || slide === null) {
+    return false
+  }
+
+  const obj = slide as Record<string, unknown>
+  
+  return (
+    (obj.type === undefined || obj.type === 'content') &&
+    (obj.title === undefined || typeof obj.title === 'string') &&
+    typeof obj.content === 'string'
+  )
+}
+
+export function validateSlideData(data: unknown): SlideData[] {
+  if (!Array.isArray(data)) {
+    throw new Error('Slides data must be an array')
+  }
+
+  if (data.length === 0) {
+    throw new Error('Slides data must contain at least one slide')
+  }
+
+  const validatedSlides: SlideData[] = []
+  const errors: string[] = []
+
+  data.forEach((slide, index) => {
+    if (typeof slide !== 'object' || slide === null) {
+      errors.push(`Slide ${index + 1}: Invalid slide format - must be an object`)
+      return
+    }
+
+    const slideObj = slide as Record<string, unknown>
+
+    if (slideObj.type === 'title') {
+      if (!isTitleSlide(slide)) {
+        const missingFields: string[] = []
+        if (typeof slideObj.title !== 'string') {
+          missingFields.push('title (string)')
+        }
+        if (slideObj.subtitle !== undefined && typeof slideObj.subtitle !== 'string') {
+          missingFields.push('subtitle must be a string')
+        }
+        if (slideObj.author !== undefined && typeof slideObj.author !== 'string') {
+          missingFields.push('author must be a string')
+        }
+        
+        errors.push(
+          `Slide ${index + 1} (title slide): Invalid or missing fields - ${missingFields.join(', ')}`
+        )
+      } else {
+        validatedSlides.push(slide)
+      }
+    } else if (slideObj.type === undefined || slideObj.type === 'content') {
+      if (!isContentSlide(slide)) {
+        const missingFields: string[] = []
+        if (typeof slideObj.content !== 'string') {
+          missingFields.push('content (string)')
+        }
+        if (slideObj.title !== undefined && typeof slideObj.title !== 'string') {
+          missingFields.push('title must be a string')
+        }
+        
+        errors.push(
+          `Slide ${index + 1} (content slide): Invalid or missing fields - ${missingFields.join(', ')}`
+        )
+      } else {
+        validatedSlides.push(slide)
+      }
+    } else {
+      errors.push(
+        `Slide ${index + 1}: Unknown slide type '${slideObj.type}'. Valid types are 'title' or 'content'`
+      )
+    }
+  })
+
+  if (errors.length > 0) {
+    throw new Error(`Validation errors:\n${errors.join('\n')}`)
+  }
+
+  return validatedSlides
+}

--- a/src/utils/yamlParser.ts
+++ b/src/utils/yamlParser.ts
@@ -1,0 +1,113 @@
+export function parseYaml(content: string): unknown[] {
+  const lines = content.split('\n')
+  const slides: unknown[] = []
+  let currentSlide: Record<string, unknown> = {}
+  let inMultilineContent = false
+  let multilineKey = ''
+  let multilineContent: string[] = []
+  let indentLevel = 0
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]
+    const trimmedLine = line.trim()
+
+    if (trimmedLine === '' && !inMultilineContent) {
+      continue
+    }
+
+    if (line.startsWith('- ') && !inMultilineContent) {
+      if (Object.keys(currentSlide).length > 0) {
+        slides.push(currentSlide)
+      }
+      currentSlide = {}
+      const rest = line.substring(2).trim()
+      
+      if (rest) {
+        const colonIndex = rest.indexOf(':')
+        if (colonIndex !== -1) {
+          const key = rest.substring(0, colonIndex).trim()
+          const value = rest.substring(colonIndex + 1).trim()
+          
+          if (value === '|') {
+            inMultilineContent = true
+            multilineKey = key
+            multilineContent = []
+            indentLevel = 0
+          } else {
+            currentSlide[key] = parseValue(value)
+          }
+        }
+      }
+    } else if (inMultilineContent) {
+      if (indentLevel === 0 && line.length > 0 && line[0] === ' ') {
+        let spaces = 0
+        for (const char of line) {
+          if (char === ' ') spaces++
+          else break
+        }
+        indentLevel = spaces
+      }
+
+      if (line.length > 0 && !line.startsWith(' '.repeat(indentLevel)) && !trimmedLine.startsWith('-')) {
+        currentSlide[multilineKey] = multilineContent.join('\n').trim()
+        inMultilineContent = false
+        multilineKey = ''
+        multilineContent = []
+        indentLevel = 0
+        i--
+      } else {
+        if (line.startsWith(' '.repeat(indentLevel))) {
+          multilineContent.push(line.substring(indentLevel))
+        } else if (trimmedLine === '') {
+          multilineContent.push('')
+        }
+      }
+    } else if (trimmedLine.includes(':') && !inMultilineContent) {
+      const colonIndex = trimmedLine.indexOf(':')
+      const key = trimmedLine.substring(0, colonIndex).trim()
+      const value = trimmedLine.substring(colonIndex + 1).trim()
+      
+      if (value === '|') {
+        inMultilineContent = true
+        multilineKey = key
+        multilineContent = []
+        indentLevel = 0
+      } else {
+        currentSlide[key] = parseValue(value)
+      }
+    }
+  }
+
+  if (inMultilineContent && multilineKey) {
+    currentSlide[multilineKey] = multilineContent.join('\n').trim()
+  }
+
+  if (Object.keys(currentSlide).length > 0) {
+    slides.push(currentSlide)
+  }
+
+  return slides
+}
+
+function parseValue(value: string): string | boolean | number {
+  const trimmed = value.trim()
+  
+  if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    return trimmed.slice(1, -1)
+  }
+  if (trimmed.startsWith("'") && trimmed.endsWith("'")) {
+    return trimmed.slice(1, -1)
+  }
+  
+  if (trimmed === 'true') return true
+  if (trimmed === 'false') return false
+  
+  if (/^-?\d+$/.test(trimmed)) {
+    return parseInt(trimmed, 10)
+  }
+  if (/^-?\d+\.\d+$/.test(trimmed)) {
+    return parseFloat(trimmed)
+  }
+  
+  return trimmed
+}


### PR DESCRIPTION
## 概要
PR#11のレビューで指摘された改善事項に対応しました。

Closes #12

## 変更内容

### 1. YAMLデータの詳細なバリデーション処理
- `isTitleSlide`と`isContentSlide`の型ガード関数を実装
- 各スライドタイプの必須フィールドをチェック
- 不正なスライドのインデックスと詳細なエラー内容を表示

### 2. 型アサーションの削除
- `as SlideData[]`の型アサーションを削除
- `validateSlideData`関数で型安全性を保証

### 3. 依存関係の更新
- js-yamlと@types/js-yamlを削除
- Node.js組み込みモジュールのみで実装

Generated with [Claude Code](https://claude.ai/code)