### PR TITLE
fix: Claude Code GitHub Actionsにnpmコマンドの実行権限を追加

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -68,6 +68,7 @@ jobs:
           #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
           
           # Optional: Add specific tools for running tests or linting
+          # Allow Claude to run npm commands for dependency installation, testing, and linting
           allowed_tools: "Bash(npm install:*),Bash(npm run:*),Bash(npm test:*),Bash(npm run build),Bash(npm run typecheck),Bash(npm run lint),Bash(npm run format),Bash(npm run check),Bash(npm run dev),Bash(npm run test)"
           
           # Optional: Skip review for certain conditions

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -68,7 +68,7 @@ jobs:
           #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
           
           # Optional: Add specific tools for running tests or linting
-          # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
+          allowed_tools: "Bash(npm install:*),Bash(npm run:*),Bash(npm test:*),Bash(npm run build),Bash(npm run typecheck),Bash(npm run lint),Bash(npm run format),Bash(npm run check),Bash(npm run dev),Bash(npm run test)"
           
           # Optional: Skip review for certain conditions
           # if: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -64,7 +64,7 @@ jobs:
           # assignee_trigger: "claude-bot"
           
           # Optional: Allow Claude to run specific commands
-          # allowed_tools: "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
+          allowed_tools: "Bash(npm install:*),Bash(npm run:*),Bash(npm test:*),Bash(npm run build),Bash(npm run typecheck),Bash(npm run lint),Bash(npm run format),Bash(npm run check),Bash(npm run dev),Bash(npm run test)"
           
           # Optional: Add custom instructions for Claude to customize its behavior for your project
           # custom_instructions: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -64,6 +64,7 @@ jobs:
           # assignee_trigger: "claude-bot"
           
           # Optional: Allow Claude to run specific commands
+          # Allow Claude to run npm commands for dependency installation, testing, and linting
           allowed_tools: "Bash(npm install:*),Bash(npm run:*),Bash(npm test:*),Bash(npm run build),Bash(npm run typecheck),Bash(npm run lint),Bash(npm run format),Bash(npm run check),Bash(npm run dev),Bash(npm run test)"
           
           # Optional: Add custom instructions for Claude to customize its behavior for your project


### PR DESCRIPTION
## Summary
- Claude Code GitHub ActionsワークフローにnpmコマンドのA実行権限を追加
- `allowed_tools`設定を有効化し、必要な権限を設定
- claude.ymlとclaude-code-review.ymlの両方に適用

## 背景
Issue #22でClaude Codeが`npm install`コマンドを実行できない問題が報告されました。
これは`allowed_tools`設定がコメントアウトされていたためです。

## 変更内容
### 追加した権限
- `npm install:*` - パッケージのインストール
- `npm run:*` - npm scripts全般
- `npm test:*` - テストコマンド
- その他の開発コマンド（build, typecheck, lint, format, check, dev, test）

### 変更したファイル
- `.github/workflows/claude.yml`
- `.github/workflows/claude-code-review.yml`

## Test plan
- [ ] GitHub Actions上でClaude Codeが`npm install`を実行できることを確認
- [ ] Issue #22でink-syntax-highlightのインストールが成功することを確認
- [ ] PRレビュー時にClaude Codeがテスト・リントを実行できることを確認

Closes #22

🤖 Generated with [Claude Code](https://claude.ai/code)