### PR TITLE
不要なindex.tsxファイルを削除する (#21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,28 +25,6 @@ npm install
 npm run dev
 ```
 
-### プログラムから使用
-
-```typescript
-import { render } from 'ink'
-import { SlideShow } from 'react-ink-slideshow'
-
-const slides = [
-  {
-    title: 'スライド1',
-    content: 'コンテンツ'
-  },
-  {
-    title: 'スライド2',
-    content: `複数行の
-コンテンツも
-サポート`
-  }
-]
-
-render(<SlideShow slides={slides} />)
-```
-
 ## キーボード操作
 
 - `←` / `→`: 前/次のスライドへ移動

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -5,7 +5,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Box, render } from 'ink';
 import yaml from 'js-yaml';
-import { SlideShow } from './index.js';
+import { SlideShow } from './components/SlideShow.js';
 import { validateSlideData } from './utils/slideValidator.js';
 // YAMLファイル読み込み
 // Note: js-yaml v4.x では load() がデフォルトで安全になったため、safeLoad() は削除されました

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,5 +1,0 @@
-export { Slide } from './components/Slide.js';
-export { SlideShow } from './components/SlideShow.js';
-export { TitleSlide } from './components/TitleSlide.js';
-export type { ContentSlideData, SlideData, TitleSlideData } from './types/slide.js';
-//# sourceMappingURL=index.d.ts.map

--- a/dist/index.d.ts.map
+++ b/dist/index.d.ts.map
@@ -1,1 +1,0 @@
-{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["../src/index.tsx"],"names":[],"mappings":"AAAA,OAAO,EAAE,KAAK,EAAE,MAAM,uBAAuB,CAAA;AAE7C,OAAO,EAAE,SAAS,EAAE,MAAM,2BAA2B,CAAA;AACrD,OAAO,EAAE,UAAU,EAAE,MAAM,4BAA4B,CAAA;AAGvD,YAAY,EAAE,gBAAgB,EAAE,SAAS,EAAE,cAAc,EAAE,MAAM,kBAAkB,CAAA"}

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,4 +1,0 @@
-export { Slide } from './components/Slide.js';
-// コンポーネントのエクスポート
-export { SlideShow } from './components/SlideShow.js';
-export { TitleSlide } from './components/TitleSlide.js';

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "react-ink-slideshow",
   "version": "1.0.0",
   "description": "Terminal-based slideshow presentation tool built with React Ink",
-  "main": "dist/index.js",
   "type": "module",
   "bin": {
     "react-ink-slideshow": "./dist/cli.js"

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -4,7 +4,7 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { Box, render } from 'ink'
 import yaml from 'js-yaml'
-import { SlideShow } from './index.js'
+import { SlideShow } from './components/SlideShow.js'
 import type { SlideData } from './types/slide.js'
 import { validateSlideData } from './utils/slideValidator.js'
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,0 @@
-export { Slide } from './components/Slide.js'
-// コンポーネントのエクスポート
-export { SlideShow } from './components/SlideShow.js'
-export { TitleSlide } from './components/TitleSlide.js'
-
-// 型定義のエクスポート
-export type { ContentSlideData, SlideData, TitleSlideData } from './types/slide.js'


### PR DESCRIPTION
## Summary
- 不要な`src/index.tsx`ファイルとその関連ファイルを削除
- CLIツール専用のシンプルな構成に変更
- README.mdからライブラリとしての使用例を削除

## 背景
このプロジェクトは「1度の発表向け」のCLIツールであり、他のプロジェクトからライブラリとして使用される想定がありません。そのため、エクスポート用のindex.tsxは不要です。

## 変更内容
1. `src/cli.tsx`のimportを`./index.js`から`./components/SlideShow.js`に変更
2. `src/index.tsx`を削除
3. `package.json`から`main`フィールドを削除（ライブラリエントリーポイントが不要のため）
4. `dist/`ディレクトリから`index.*`ファイルを削除
5. `README.md`から「プログラムから使用」セクションを削除

## Test plan
- [x] `npm run build` - ビルドが成功すること
- [x] `npm test` - 全てのテストが通ること
- [x] `npm run check` - 品質チェックが全て通ること
- [x] `npm run dev` - 開発モードで正常に動作すること

Closes #21

🤖 Generated with [Claude Code](https://claude.ai/code)