### PR TITLE
refactor: contentProcessor.tsxを単一責任の原則に従って再構成

### DIFF
--- a/dist/utils/contentProcessor.d.ts.map
+++ b/dist/utils/contentProcessor.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"contentProcessor.d.ts","sourceRoot":"","sources":["../../src/utils/contentProcessor.tsx"],"names":[],"mappings":"AAEA,OAAO,KAAK,MAAM,OAAO,CAAA;AAEzB,wBAAgB,cAAc,CAAC,OAAO,EAAE,MAAM,GAAG,KAAK,CAAC,GAAG,CAAC,OAAO,CAqFjE"}
+{"version":3,"file":"contentProcessor.d.ts","sourceRoot":"","sources":["../../src/utils/contentProcessor.tsx"],"names":[],"mappings":"AAEA,OAAO,KAAK,MAAM,OAAO,CAAA;AAiJzB,wBAAgB,cAAc,CAAC,OAAO,EAAE,MAAM,GAAG,KAAK,CAAC,GAAG,CAAC,OAAO,CAIjE"}

--- a/src/utils/contentProcessor.tsx
+++ b/src/utils/contentProcessor.tsx
@@ -2,89 +2,151 @@ import { Newline, Text } from 'ink'
 import SyntaxHighlight from 'ink-syntax-highlight'
 import React from 'react'
 
-export function processContent(content: string): React.JSX.Element {
+type TextLine = {
+  type: 'text'
+  content: string
+}
+
+type HeadingLine = {
+  type: 'heading'
+  content: string
+}
+
+type CodeBlock = {
+  type: 'codeBlock'
+  language?: string
+  lines: string[]
+}
+
+type ContentElement = TextLine | HeadingLine | CodeBlock
+
+function parseContent(content: string): ContentElement[] {
   const lines = content.split('\n')
-  let inCodeBlock = false
-  let codeBlockStartLine = -1
-  let codeBlockLanguage = ''
-  let codeBlockContent: string[] = []
-  const elements: React.ReactNode[] = []
+  const elements: ContentElement[] = []
+  let i = 0
 
-  lines.forEach((line, index) => {
+  while (i < lines.length) {
+    const line = lines[i]
+
     if (line.startsWith('```')) {
-      if (!inCodeBlock) {
-        // コードブロック開始
-        codeBlockStartLine = index
-        codeBlockLanguage = line.slice(3).trim() // ```の後の言語を取得
-        codeBlockContent = []
-      } else {
-        // コードブロック終了
-        if (codeBlockContent.length > 0) {
-          // 最初の行以外は改行を追加
-          if (elements.length > 0) {
-            // biome-ignore lint/suspicious/noArrayIndexKey: スライドコンテンツは静的であり、順序が変更されることはないため
-            elements.push(<Newline key={`newline-${index}-pre`} />)
-          }
-
-          if (codeBlockLanguage) {
-            // 言語が指定されている場合はSyntaxHighlightを使用
-            elements.push(
-              <SyntaxHighlight
-                key={`codeblock-${codeBlockStartLine}`}
-                code={codeBlockContent.join('\n')}
-                language={codeBlockLanguage}
-              />,
-            )
-          } else {
-            // 言語が指定されていない場合は従来通り緑色で表示
-            codeBlockContent.forEach((codeLine, codeIndex) => {
-              if (codeIndex > 0) {
-                // biome-ignore lint/suspicious/noArrayIndexKey: スライドコンテンツは静的であり、順序が変更されることはないため
-                elements.push(<Newline key={`newline-${codeBlockStartLine}-${codeIndex}`} />)
-              }
-              elements.push(
-                // biome-ignore lint/suspicious/noArrayIndexKey: スライドコンテンツは静的であり、順序が変更されることはないため
-                <Text key={`line-${codeBlockStartLine}-${codeIndex}`} color="green">
-                  {'  '}
-                  {codeLine}
-                </Text>,
-              )
-            })
-          }
-        }
+      const codeBlock = parseCodeBlock(lines, i)
+      if (codeBlock) {
+        elements.push(codeBlock.element)
+        i = codeBlock.endIndex + 1
+        continue
       }
-      inCodeBlock = !inCodeBlock
-      return
     }
 
-    // 最初の行以外は改行を追加
-    if (elements.length > 0) {
-      // biome-ignore lint/suspicious/noArrayIndexKey: スライドコンテンツは静的であり、順序が変更されることはないため
-      elements.push(<Newline key={`newline-${index}`} />)
-    }
-
-    if (inCodeBlock) {
-      // コードブロック内のコンテンツを収集
-      codeBlockContent.push(line)
-    } else if (line.startsWith('#')) {
-      elements.push(
-        // biome-ignore lint/suspicious/noArrayIndexKey: スライドコンテンツは静的であり、順序が変更されることはないため
-        <Text key={`line-${index}`} bold color="cyan">
-          {line}
-        </Text>,
-      )
+    if (line.startsWith('#')) {
+      elements.push({ type: 'heading', content: line })
     } else {
-      // biome-ignore lint/suspicious/noArrayIndexKey: スライドコンテンツは静的であり、順序が変更されることはないため
-      elements.push(<Text key={`line-${index}`}>{line}</Text>)
+      elements.push({ type: 'text', content: line })
     }
-  })
 
-  // 未閉じのコードブロックがある場合の警告
-  // codeBlockStartLine !== -1 のチェックは論理的には不要だが、
-  // 防御的プログラミングの観点から明示的にチェック
-  if (inCodeBlock && process.env.NODE_ENV !== 'production' && codeBlockStartLine !== -1) {
-    console.warn(`Warning: Unclosed code block starting at line ${codeBlockStartLine + 1}`)
+    i++
   }
 
-  return <Text>{elements}</Text>
+  return elements
+}
+
+function parseCodeBlock(
+  lines: string[],
+  startIndex: number,
+): { element: CodeBlock; endIndex: number } | null {
+  const startLine = lines[startIndex]
+  if (!startLine.startsWith('```')) return null
+
+  const language = startLine.slice(3).trim()
+  const codeLines: string[] = []
+  let endIndex = startIndex
+
+  for (let i = startIndex + 1; i < lines.length; i++) {
+    if (lines[i] === '```') {
+      endIndex = i
+      return {
+        element: {
+          type: 'codeBlock',
+          language: language || undefined,
+          lines: codeLines,
+        },
+        endIndex,
+      }
+    }
+    codeLines.push(lines[i])
+  }
+
+  if (process.env.NODE_ENV !== 'production') {
+    console.warn(`Warning: Unclosed code block starting at line ${startIndex + 1}`)
+  }
+
+  return {
+    element: {
+      type: 'codeBlock',
+      language: language || undefined,
+      lines: codeLines,
+    },
+    endIndex: lines.length - 1,
+  }
+}
+
+function renderElements(elements: ContentElement[]): React.ReactNode[] {
+  const result: React.ReactNode[] = []
+
+  elements.forEach((element, index) => {
+    if (index > 0) {
+      // biome-ignore lint/suspicious/noArrayIndexKey: スライドコンテンツは静的であり、順序が変更されることはないため
+      result.push(<Newline key={`newline-${index}`} />)
+    }
+
+    const rendered = renderElement(element, index)
+    result.push(rendered)
+  })
+
+  return result
+}
+
+function renderElement(element: ContentElement, index: number): React.ReactNode {
+  switch (element.type) {
+    case 'heading':
+      return (
+        <Text key={`heading-${index}`} bold color="cyan">
+          {element.content}
+        </Text>
+      )
+
+    case 'text':
+      return <Text key={`text-${index}`}>{element.content}</Text>
+
+    case 'codeBlock':
+      if (element.lines.length === 0) {
+        return null
+      }
+
+      if (element.language) {
+        return (
+          <SyntaxHighlight
+            key={`codeblock-${index}`}
+            code={element.lines.join('\n')}
+            language={element.language}
+          />
+        )
+      } else {
+        return element.lines.map((line, lineIndex) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: スライドコンテンツは静的であり、順序が変更されることはないため
+          <React.Fragment key={`code-${index}-${lineIndex}`}>
+            {lineIndex > 0 && <Newline />}
+            <Text color="green">
+              {'  '}
+              {line}
+            </Text>
+          </React.Fragment>
+        ))
+      }
+  }
+}
+
+export function processContent(content: string): React.JSX.Element {
+  const elements = parseContent(content)
+  const rendered = renderElements(elements)
+  return <Text>{rendered}</Text>
 }


### PR DESCRIPTION
## Summary
- contentProcessor.tsxを単一責任の原則に従ってリファクタリング
- コードの可読性と保守性を向上
- テストカバレッジは変更なし（全テスト合格）

## 変更内容

### 1. 型定義の追加
```typescript
type TextLine = { type: 'text'; content: string }
type HeadingLine = { type: 'heading'; content: string }
type CodeBlock = { type: 'codeBlock'; language?: string; lines: string[] }
type ContentElement = TextLine | HeadingLine | CodeBlock
```

### 2. 責務の分離
- **parseContent**: テキストを構造化されたContentElement配列に変換
- **parseCodeBlock**: コードブロックの解析を専門に処理
- **renderElements/renderElement**: ContentElementをReactコンポーネントに変換
- **processContent**: パースとレンダリングを統合するシンプルな関数

### 3. 改善点
- 各関数が単一の責務を持つようになった
- 状態管理がシンプルになった（4つの変数 → 構造化データ）
- テストが容易になった
- コードの可読性が向上

## Test plan
- [x] 全ての既存テストが合格することを確認
- [x] TypeScript型チェックが通ることを確認
- [x] Biomeのリント・フォーマットチェックが通ることを確認
- [x] ビルドが正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)