### PR TITLE
feat: Markdownのboldテキスト(**テキスト**)表示機能を追加

### DIFF
--- a/dist/utils/contentProcessor.d.ts.map
+++ b/dist/utils/contentProcessor.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"contentProcessor.d.ts","sourceRoot":"","sources":["../../src/utils/contentProcessor.tsx"],"names":[],"mappings":"AAEA,OAAO,KAAK,MAAM,OAAO,CAAA;AAuJzB,wBAAgB,cAAc,CAAC,OAAO,EAAE,MAAM,GAAG,KAAK,CAAC,GAAG,CAAC,OAAO,CAIjE"}
+{"version":3,"file":"contentProcessor.d.ts","sourceRoot":"","sources":["../../src/utils/contentProcessor.tsx"],"names":[],"mappings":"AAEA,OAAO,KAAK,MAAM,OAAO,CAAA;AAuLzB,wBAAgB,cAAc,CAAC,OAAO,EAAE,MAAM,GAAG,KAAK,CAAC,GAAG,CAAC,OAAO,CAIjE"}

--- a/dist/utils/contentProcessor.js
+++ b/dist/utils/contentProcessor.js
@@ -82,7 +82,7 @@ function renderElement(element, index) {
         case 'heading':
             return (_jsx(Text, { bold: true, color: "cyan", children: element.content }, `heading-${index}`));
         case 'text':
-            return _jsx(Text, { children: element.content }, `text-${index}`);
+            return _jsx(Text, { children: renderTextWithFormatting(element.content) }, `text-${index}`);
         case 'codeBlock':
             if (element.lines.length === 0) {
                 return null;
@@ -96,6 +96,28 @@ function renderElement(element, index) {
                 _jsxs(React.Fragment, { children: [lineIndex > 0 && _jsx(Newline, {}), _jsxs(Text, { color: "green", children: ['  ', line] })] }, `code-${index}-${lineIndex}`)));
             }
     }
+}
+function renderTextWithFormatting(text) {
+    const parts = [];
+    const boldRegex = /\*\*([^*]+)\*\*/g;
+    let lastIndex = 0;
+    let match;
+    match = boldRegex.exec(text);
+    while (match !== null) {
+        // 通常のテキスト部分
+        if (match.index > lastIndex) {
+            parts.push(text.slice(lastIndex, match.index));
+        }
+        // ボールドテキスト部分
+        parts.push(_jsx(Text, { bold: true, children: match[1] }, `bold-${match.index}`));
+        lastIndex = match.index + match[0].length;
+        match = boldRegex.exec(text);
+    }
+    // 最後の通常テキスト部分
+    if (lastIndex < text.length) {
+        parts.push(text.slice(lastIndex));
+    }
+    return parts.length === 0 ? text : parts;
 }
 export function processContent(content) {
     const elements = parseContent(content);

--- a/src/utils/contentProcessor.tsx
+++ b/src/utils/contentProcessor.tsx
@@ -121,7 +121,7 @@ function renderElement(element: ContentElement, index: number): React.ReactNode 
       )
 
     case 'text':
-      return <Text key={`text-${index}`}>{element.content}</Text>
+      return <Text key={`text-${index}`}>{renderTextWithFormatting(element.content)}</Text>
 
     case 'codeBlock':
       if (element.lines.length === 0) {
@@ -149,6 +149,38 @@ function renderElement(element: ContentElement, index: number): React.ReactNode 
         ))
       }
   }
+}
+
+function renderTextWithFormatting(text: string): React.ReactNode {
+  const parts: React.ReactNode[] = []
+  const boldRegex = /\*\*([^*]+)\*\*/g
+  let lastIndex = 0
+  let match: RegExpExecArray | null
+
+  match = boldRegex.exec(text)
+  while (match !== null) {
+    // 通常のテキスト部分
+    if (match.index > lastIndex) {
+      parts.push(text.slice(lastIndex, match.index))
+    }
+
+    // ボールドテキスト部分
+    parts.push(
+      <Text key={`bold-${match.index}`} bold>
+        {match[1]}
+      </Text>,
+    )
+
+    lastIndex = match.index + match[0].length
+    match = boldRegex.exec(text)
+  }
+
+  // 最後の通常テキスト部分
+  if (lastIndex < text.length) {
+    parts.push(text.slice(lastIndex))
+  }
+
+  return parts.length === 0 ? text : parts
 }
 
 export function processContent(content: string): React.JSX.Element {

--- a/tests/contentProcessor.test.tsx
+++ b/tests/contentProcessor.test.tsx
@@ -1,5 +1,5 @@
 import { render } from 'ink-testing-library'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { processContent } from '../src/utils/contentProcessor'
 
 describe('processContent', () => {
@@ -130,5 +130,49 @@ describe('processContent', () => {
     expect(output).toContain('template')
     expect(output).toContain('Hello')
     expect(output).toContain('name')
+  })
+
+  describe('テキストフォーマット', () => {
+    it('**テキスト**をボールドで表示する', () => {
+      const content = 'これは**重要な**テキストです'
+      const { lastFrame } = render(processContent(content))
+      const output = lastFrame()
+      expect(output).toContain('これは')
+      expect(output).toContain('重要な')
+      expect(output).toContain('テキストです')
+    })
+
+    it('複数のボールドテキストを処理できる', () => {
+      const content = '**最初**の部分と**二番目**の部分'
+      const { lastFrame } = render(processContent(content))
+      const output = lastFrame()
+      expect(output).toContain('最初')
+      expect(output).toContain('の部分と')
+      expect(output).toContain('二番目')
+      expect(output).toContain('の部分')
+    })
+
+    it('ボールドテキストが行頭にある場合', () => {
+      const content = '**重要**：この内容に注意'
+      const { lastFrame } = render(processContent(content))
+      const output = lastFrame()
+      expect(output).toContain('重要')
+      expect(output).toContain('：この内容に注意')
+    })
+
+    it('ボールドテキストが行末にある場合', () => {
+      const content = 'この内容は**重要**'
+      const { lastFrame } = render(processContent(content))
+      const output = lastFrame()
+      expect(output).toContain('この内容は')
+      expect(output).toContain('重要')
+    })
+
+    it('ボールドマークが不完全な場合は通常のテキストとして扱う', () => {
+      const content = 'これは**不完全なテキスト'
+      const { lastFrame } = render(processContent(content))
+      const output = lastFrame()
+      expect(output).toContain('これは**不完全なテキスト')
+    })
   })
 })


### PR DESCRIPTION
## Summary
- スライドコンテンツ内で`**テキスト**`記法を使用してボールド表示を実現
- React Inkの`<Text bold>`コンポーネントを利用した実装
- 複数のボールドテキストや行頭・行末での表示にも対応

## Test plan
- [x] `npm test`が全て成功することを確認
- [x] `npm run check`（型チェック、テスト、フォーマット、リント）が全て成功することを確認
- [ ] `npm run dev`で実際にボールドテキストが表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)