### PR TITLE
feat: Claude botにIssue作成権限を付与

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-      issues: read
+      issues: write  # Changed from read to write to allow Claude to create issues
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -68,10 +68,16 @@ jobs:
           allowed_tools: "Bash(npm install:*),Bash(npm run:*),Bash(npm test:*),Bash(npm run build),Bash(npm run typecheck),Bash(npm run lint),Bash(npm run format),Bash(npm run check),Bash(npm run dev),Bash(npm run test)"
           
           # Optional: Add custom instructions for Claude to customize its behavior for your project
-          # custom_instructions: |
-          #   Follow our coding standards
-          #   Ensure all new code has tests
-          #   Use TypeScript for new files
+          custom_instructions: |
+            Follow our coding standards
+            Ensure all new code has tests
+            Use TypeScript for new files
+            
+            # GitHub Issue作成に関するルール
+            - Issueの作成はユーザーから明示的に指示された場合のみ行うこと
+            - 新規Issueの作成のみ許可（既存Issueの更新・削除は禁止）
+            - Issueへの対応者（assignee）のアサインは行わないこと
+            - Issueのクローズ・再オープンは行わないこと
           
           # Optional: Custom environment variables for Claude
           # claude_env: |


### PR DESCRIPTION
## Summary
- GitHub Actionsの`claude.yml`でissues権限を`read`から`write`に変更
- これにより`@claude` botがGitHub Issueを作成できるようになります
- custom_instructionsでIssue作成のガイドラインを定義

## Test plan
詳細なテスト項目は Issue #34 に記載しています。

- [ ] この変更をマージ後、Issue #34 の各テスト項目を実施
  - [ ] Issueやコメントで`@claude`をメンションして明示的にIssue作成を依頼した際に、正しく新規Issueが作成されること
  - [ ] 明示的な指示なしでは`@claude`がIssue作成を行わないこと
  - [ ] `@claude`が既存Issueの更新・削除を拒否すること
  - [ ] `@claude`がassigneeのアサインを行わないこと
  - [ ] `@claude`がIssueのクローズ・再オープンを行わないこと

## 関連Issue
- #32: `@claude` bot が GitHub Issue を作れるようにしたい
- #34: test: Claude botのIssue作成機能の動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)