### PR TITLE
fix: Claude botにGitHub CLIコマンドの実行権限を追加

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -65,7 +65,7 @@ jobs:
           
           # Optional: Allow Claude to run specific commands
           # Allow Claude to run npm commands for dependency installation, testing, and linting
-          allowed_tools: "Bash(npm install:*),Bash(npm run:*),Bash(npm test:*),Bash(npm run build),Bash(npm run typecheck),Bash(npm run lint),Bash(npm run format),Bash(npm run check),Bash(npm run dev),Bash(npm run test)"
+          allowed_tools: "Bash(npm install:*),Bash(npm run:*),Bash(npm test:*),Bash(npm run build),Bash(npm run typecheck),Bash(npm run lint),Bash(npm run format),Bash(npm run check),Bash(npm run dev),Bash(npm run test),Bash(gh issue create),Bash(gh issue view:*),Bash(gh issue list),Bash(gh issue comment:*)"
           
           # Optional: Add custom instructions for Claude to customize its behavior for your project
           custom_instructions: |


### PR DESCRIPTION
## Summary
PR #33でClaude botにIssue作成権限を付与しましたが、`allowed_tools`にGitHub CLIコマンドが含まれていなかったため、実際にはIssueを作成できませんでした。

この修正では、`allowed_tools`に以下のGitHub CLIコマンドを追加します：
- `gh issue create` - 新規Issue作成
- `gh issue view:*` - Issue閲覧
- `gh issue list` - Issue一覧表示
- `gh issue comment:*` - Issueへのコメント追加

## Changes
- `.github/workflows/claude.yml`の`allowed_tools`にGitHub CLIコマンドを追加

## Test plan
- [ ] マージ後、Issue #34 のテスト項目を再実施
- [ ] 特に「@claude 新しいIssueを作成してください」のテストで実際にIssueが作成されることを確認

## 関連Issue/PR
- #32: `@claude` bot が GitHub Issue を作れるようにしたい
- #33: feat: Claude botにIssue作成権限を付与
- #34: test: Claude botのIssue作成機能の動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)